### PR TITLE
Update monster targeting logic

### DIFF
--- a/src/mechanics.js
+++ b/src/mechanics.js
@@ -7247,12 +7247,11 @@ function processTurn() {
                 
                 let nearestTarget = null;
                 let nearestDistance = Infinity;
-                
+
                 // 가장 가까운 대상 찾기
-                const playerDistance = getDistance(monster.x, monster.y, gameState.player.x, gameState.player.y);
-                if (playerDistance <= MONSTER_VISION) { // 이동 + 공격 범위
+                if (distToPlayer <= MONSTER_VISION) { // 이동 + 공격 범위
                     nearestTarget = gameState.player;
-                    nearestDistance = playerDistance;
+                    nearestDistance = distToPlayer;
                 }
                 
                 gameState.activeMercenaries.forEach(mercenary => {


### PR DESCRIPTION
## Summary
- skip far monsters before champion/superior logic
- reuse precomputed distance when selecting the nearest target

## Testing
- `npm test` *(fails: corpseDecay.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684e59b2fbe08327a3c0e7470a6d1a8d