### PR TITLE
Remove pulse animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,19 +104,16 @@
             background: radial-gradient(circle, #f44336, #d32f2f);
             color: white;
             box-shadow: 0 0 6px rgba(244, 67, 54, 0.5);
-            animation: monsterPulse 1.5s ease-in-out infinite alternate;
         }
         .champion {
             background: radial-gradient(circle, #ff9800, #f57c00);
             color: white;
             box-shadow: 0 0 8px rgba(255, 152, 0, 0.7);
-            animation: monsterPulse 1.5s ease-in-out infinite alternate;
         }
         .elite {
             background: radial-gradient(circle, #9C27B0, #7B1FA2);
             color: white;
             box-shadow: 0 0 8px rgba(156, 39, 176, 0.7);
-            animation: monsterPulse 1.5s ease-in-out infinite alternate;
         }
         @keyframes monsterPulse {
             from { transform: scale(1); }
@@ -130,7 +127,6 @@
             background-repeat: no-repeat, no-repeat;
             color: transparent;
             box-shadow: 0 0 10px rgba(255, 215, 0, 0.7);
-            animation: treasureSparkle 1s ease-in-out infinite alternate;
             font-size: 20px;
         }
         @keyframes treasureSparkle {
@@ -241,7 +237,6 @@
             background-position: center;
             color: white;
             box-shadow: 0 0 15px rgba(0, 188, 212, 0.8);
-            animation: exitPortal 2s ease-in-out infinite;
             font-size: 20px;
             border: 2px solid #B2EBF2;
         }

--- a/style.css
+++ b/style.css
@@ -202,20 +202,17 @@
 /* ---- Special unit glow effects ---- */
 .cell.elite {
   box-shadow: 0 0 8px rgba(244, 67, 54, 0.7);
-  animation: monsterPulse 1.5s ease-in-out infinite alternate;
 }
 
 .cell.champion {
-  /* BUG FIX: 챔피언 셀의 배경색을 명시적으로 투명하게 설정하여 
+  /* BUG FIX: 챔피언 셀의 배경색을 명시적으로 투명하게 설정하여
      하위 바닥 타일 이미지가 보이도록 수정합니다. */
   background-color: transparent;
   box-shadow: 0 0 8px rgba(255, 235, 59, 0.7);
-  animation: monsterPulse 1.5s ease-in-out infinite alternate;
 }
 
 .cell.superior {
   box-shadow: 0 0 8px rgba(33, 150, 243, 0.7);
-  animation: monsterPulse 1.5s ease-in-out infinite alternate;
 }
 
 .inv-filter-btn {


### PR DESCRIPTION
## Summary
- stop pulsing animations on elite, champion, and treasure tiles
- keep color glow effects only

## Testing
- `npm test` *(fails: saveGame not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684e5df2fb888327ab5d6347d915cdaa