### PR TITLE
Enable direct page load

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,7 @@ This project is a lightweight browser-based dungeon crawler. It lets players exp
 
 Open `index.html` in a modern web browser to start the game. The player now begins with every available skill already learned, so no class selection is required.
 
-```bash
-npx http-server
-```
-
-Running a small HTTP server from the project directory is recommended because some browsers block
-ES module loading when opening the file directly via `file://`. You can still open `index.html`
-without a server, but you may need to adjust browser settings to permit local module imports.
+A local server is no longer required – simply open `index.html` directly.
 
 ### Dungeon Generation
 Each floor is carved from a depth-first search maze. Corridors span seven tiles,

--- a/index.html
+++ b/index.html
@@ -1025,9 +1025,9 @@
     </div>
     <audio id="bgm-player"></audio>
     <script src="dice.js"></script>
-    <script type="module" src="src/state.js"></script>
-    <script type="module" src="src/ui.js"></script>
-    <script type="module" src="src/mechanics.js"></script>
+    <script src="src/state.js"></script>
+    <script src="src/ui.js"></script>
+    <script src="src/mechanics.js"></script>
     <script>
         function updateLogTextColor() {
             const styles = getComputedStyle(document.documentElement);


### PR DESCRIPTION
## Summary
- allow direct launch of index.html by removing module type on scripts
- update docs for simpler setup

## Testing
- `npm test` *(fails: Could not load script `http://localhost/src/state.js`)*

------
https://chatgpt.com/codex/tasks/task_e_684e64a3af6883278426ca6e26915faa